### PR TITLE
Bugfix1

### DIFF
--- a/SeisSeeker/processing/detection.py
+++ b/SeisSeeker/processing/detection.py
@@ -246,7 +246,7 @@ def _phase_associator(t_series_df_Z, t_series_df_hor, peaks_Z, peaks_hor, bazi_t
             max_power_event = _find_max_power_event(tmp_lst)
             filt_events_lst.append(max_power_event)
             # Now make new DataFrame
-            filt_event_df = pd.DataFrame(filt_events_df)
+            filt_events_df = pd.DataFrame(filt_events_lst)
             # And sort indices:
             filt_events_df.reset_index(drop=True, inplace=True)
 
@@ -1101,7 +1101,7 @@ class setup_detection:
         """
         print("Note: <mad_window_length_s> not yet implemented.")
         # Create datastore:
-        events_df_all = pd.DataFrame()
+        evenbts_df_all = pd.DataFrame()
         # Loop over array proc outdir data:
         for fname in glob.glob(os.path.join(self.outdir, "detection_t_series_*_chZ.csv")):
             f_uid = fname[-20:-8]
@@ -1178,7 +1178,7 @@ class setup_detection:
                 events_df = self._calc_uncertainties(events_df, t_series_df_Z, t_series_df_hor, verbosity=verbosity)
 
             # Append to datastore:
-            events_df_all = events_df_all.append(events_df)
+            events_df_all = pd.concat([events_df_all, events_df])
 
             # Plot detected, phase-associated picks:
             if verbosity > 1:

--- a/SeisSeeker/processing/detection.py
+++ b/SeisSeeker/processing/detection.py
@@ -227,12 +227,13 @@ def _phase_associator(t_series_df_Z, t_series_df_hor, peaks_Z, peaks_hor, bazi_t
                 tmp_count+=1
                 if tmp_count == 1:
                     tmp_lst = []
-                    tmp_lst = tmp_lst.append(row)
+                    tmp_lst.append(row)
                 else:
+
                     # Append event if phase within minimum event separation:
                     if obspy.UTCDateTime(row['t1']) - obspy.UTCDateTime(tmp_lst[0].t1) < min_event_sep_s:
                         # Append event to compare:
-                        tmp_lst = tmp_lst.append(row)
+                        tmp_lst.append(row)
                     else:
                         # Find best event from previous events:
                         max_power_event = _find_max_power_event(tmp_lst)
@@ -240,7 +241,7 @@ def _phase_associator(t_series_df_Z, t_series_df_hor, peaks_Z, peaks_hor, bazi_t
 
                         # And start acrewing new events:
                         tmp_lst = []
-                        tmp_lst = tmp_lst.append(row)
+                        tmp_lst.append(row)
             # And calculate highest power event for final window:
             max_power_event = _find_max_power_event(tmp_lst)
             filt_events_lst.append(max_power_event)

--- a/SeisSeeker/processing/detection.py
+++ b/SeisSeeker/processing/detection.py
@@ -85,10 +85,10 @@ def _fast_freq_domain_array_proc(data, max_sl, fs, target_freqs, xx, yy, n_stati
         # Construct data structure:
         nfft = (2.0**np.ceil(np.log2(n_t_samp)))
         nfft = np.array(nfft, dtype=np.int64)
-        Pxx_all = np.zeros((np.int((nfft/2)+1), n_stations), dtype=np.complex128) # Power spectra
+        Pxx_all = np.zeros((np.int64((nfft/2)+1), n_stations), dtype=np.complex128) # Power spectra
         dt = 1. / fs 
         df = 1.0/(2.0*nfft*dt)
-        xf = np.linspace(0.0, 1.0/(2.0*dt), np.int((nfft/2)+1))
+        xf = np.linspace(0.0, 1.0/(2.0*dt), np.int64((nfft/2)+1))
         # Calculate power spectra for all stations:
         for sta_idx in range(n_stations):
             # Calculate spectra for current station:

--- a/SeisSeeker/processing/detection.py
+++ b/SeisSeeker/processing/detection.py
@@ -791,7 +791,7 @@ class setup_detection:
                             continue
 
                         # Create datastore:
-                        out_df = pd.DataFrame({'t': [], 'power': [], 'slowness': [], 'back_azi': []})
+                        datastore = {'t': [], 'power': [], 'slowness': [], 'back_azi': []}
 
                         # Load data:
                         st = self._load_day_of_data(year, julday, hour=hour)
@@ -846,8 +846,11 @@ class setup_detection:
                             else:
                                 for t_serie in t_series:
                                     t_series_out.append( str(starttime_this_st + t_serie) )
-                            tmp_df = pd.DataFrame({'t': t_series_out, 'power': powers, 'slowness': slownesses, 'back_azi': back_azis})
-                            out_df = out_df.append(tmp_df)
+                            datastore['t'].append(t_series_out)
+                            datastore['power'].append(powers)
+                            datastore['slowness'].append(slownesses)
+                            datastore['back_azi'].append(back_azis)
+                            out_df = pd.DataFrame(datastore, columns=['t', 'power', 'slowness', 'back_azi'])
                             out_df.reset_index(drop=True, inplace=True)
 
                             # And save data out:

--- a/SeisSeeker/processing/detection.py
+++ b/SeisSeeker/processing/detection.py
@@ -791,7 +791,7 @@ class setup_detection:
                             continue
 
                         # Create datastore:
-                        datastore = {'t': [], 'power': [], 'slowness': [], 'back_azi': []}
+                        store_df = pd.DataFrame({'t': [], 'power': [], 'slowness': [], 'back_azi': []})
 
                         # Load data:
                         st = self._load_day_of_data(year, julday, hour=hour)
@@ -846,11 +846,8 @@ class setup_detection:
                             else:
                                 for t_serie in t_series:
                                     t_series_out.append( str(starttime_this_st + t_serie) )
-                            datastore['t'].append(t_series_out)
-                            datastore['power'].append(powers)
-                            datastore['slowness'].append(slownesses)
-                            datastore['back_azi'].append(back_azis)
-                            out_df = pd.DataFrame(datastore, columns=['t', 'power', 'slowness', 'back_azi'])
+                            tmp_df = pd.DataFrame({'t': t_series_out, 'power': powers, 'slowness': slownesses, 'back_azi': back_azis})
+                            out_df = pd.concat([store_df, tmp_df])
                             out_df.reset_index(drop=True, inplace=True)
 
                             # And save data out:

--- a/SeisSeeker/processing/detection.py
+++ b/SeisSeeker/processing/detection.py
@@ -1101,7 +1101,7 @@ class setup_detection:
         """
         print("Note: <mad_window_length_s> not yet implemented.")
         # Create datastore:
-        evenbts_df_all = pd.DataFrame()
+        events_df_all = pd.DataFrame()
         # Loop over array proc outdir data:
         for fname in glob.glob(os.path.join(self.outdir, "detection_t_series_*_chZ.csv")):
             f_uid = fname[-20:-8]

--- a/SeisSeeker/processing/detection.py
+++ b/SeisSeeker/processing/detection.py
@@ -253,9 +253,10 @@ def _phase_associator(t_series_df_Z, t_series_df_hor, peaks_Z, peaks_hor, bazi_t
             sum_pows = filt_events_df['pow1'].values + filt_events_df['pow2'].values
             filt_events_df['sum_pows'] = sum_pows
             # Remove t2 duplicates, keep highest summed power:
-            filt_events_df = filt_events_df.sort_values('sum_pows').drop_duplicates(subset='t2', keep='last')
+            filt_events_df.sort_values('sum_pows', inplace=True)
+            filt_events_df.drop_duplicates(subset='t2', keep='last', inplace=True)
             # And remove sum_pows column:
-            filt_events_df = filt_events_df.drop(columns=['sum_pows'])
+            filt_events_df.drop(columns=['sum_pows'], inplace=True)
 
             # And output df:
             events_df = filt_events_df.copy()

--- a/SeisSeeker/processing/detection.py
+++ b/SeisSeeker/processing/detection.py
@@ -203,6 +203,7 @@ def _phase_associator(t_series_df_Z, t_series_df_hor, peaks_Z, peaks_hor, bazi_t
                                             'pow1': [t_series_df_Z['power'][curr_peak_Z_idx]], 'pow2': [t_series_df_hor['power'][curr_peak_hor_idx]], 
                                             'slow1': [t_series_df_Z['slowness'][curr_peak_Z_idx]], 'slow2': [t_series_df_hor['slowness'][curr_peak_hor_idx]], 
                                             'bazi1': [t_series_df_Z['back_azi'][curr_peak_Z_idx]], 'bazi2': [t_series_df_hor['back_azi'][curr_peak_hor_idx]]})
+        print(curr_event_df)
         events_df = events_df.append(curr_event_df)
     # And tidy:
     del t_Z_secs_after_start, t_hor_secs_after_start, Z_hor_phase_pair_idxs

--- a/SeisSeeker/processing/detection.py
+++ b/SeisSeeker/processing/detection.py
@@ -173,7 +173,7 @@ def _phase_associator(t_series_df_Z, t_series_df_hor, peaks_Z, peaks_hor, bazi_t
     Function to perform phase association for numba implementation.
     """
     # Setup events datastores:
-    events_df = pd.DataFrame()
+    list_of_curr_event_dfs = []
     # Find back-azimuths associated with phase picks:
     bazis_Z = t_series_df_Z['back_azi'].values[peaks_Z]
     bazis_hor = t_series_df_hor['back_azi'].values[peaks_hor]
@@ -203,8 +203,10 @@ def _phase_associator(t_series_df_Z, t_series_df_hor, peaks_Z, peaks_hor, bazi_t
                                             'pow1': [t_series_df_Z['power'][curr_peak_Z_idx]], 'pow2': [t_series_df_hor['power'][curr_peak_hor_idx]], 
                                             'slow1': [t_series_df_Z['slowness'][curr_peak_Z_idx]], 'slow2': [t_series_df_hor['slowness'][curr_peak_hor_idx]], 
                                             'bazi1': [t_series_df_Z['back_azi'][curr_peak_Z_idx]], 'bazi2': [t_series_df_hor['back_azi'][curr_peak_hor_idx]]})
+        list_of_curr_event_dfs.append(curr_event_df)
         print(curr_event_df)
-        events_df = events_df.append(curr_event_df)
+    
+    events_df = pd.concat(list_of_curr_event_dfs)
     # And tidy:
     del t_Z_secs_after_start, t_hor_secs_after_start, Z_hor_phase_pair_idxs
     gc.collect()

--- a/examples/rutford_icequake_example/rutford_icequake_example.ipynb
+++ b/examples/rutford_icequake_example/rutford_icequake_example.ipynb
@@ -40,7 +40,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -59,7 +59,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -77,17 +77,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Min. inter-station distance: 0.0193294780285 km\n",
-      "Therefore, optimal sensitive higher freq.: 98.2954633955 Hz\n",
-      "Max. inter-station distance: 0.0923463197348 km\n",
-      "Therefore, optimal sensitive lower freq.: 20.5747235565 Hz\n"
+      "Min. inter-station distance: 0.019329478028457248 km\n",
+      "Therefore, optimal sensitive higher freq.: 98.29546339548236 Hz\n",
+      "Max. inter-station distance: 0.09234631973482979 km\n",
+      "Therefore, optimal sensitive lower freq.: 20.574723556453616 Hz\n"
      ]
     }
    ],
@@ -120,39 +120,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Define a suitable event for using in this example:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 11,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# # Specify data to load:\n",
-    "# archive = \"inputs/mseed_data_archive\"\n",
-    "# year = 2020\n",
-    "# julday = 1\n",
-    "# hour = 1\n",
-    "# station_codes_to_use = \"A\"\n",
-    "# freqmin = 10\n",
-    "# freqmax = 150\n",
-    "# mseed_dir = os.path.join(archive, str(year), str(julday).zfill(3))\n",
-    "\n",
-    "# # Load data:\n",
-    "# st = obspy.read(os.path.join(mseed_dir, ''.join((str(year), str(julday).zfill(3), \"_\", str(hour).zfill(2), \"*\", station_codes_to_use, \"*\"))))\n",
-    "\n",
-    "# # And filter:\n",
-    "# st.filter('bandpass', freqmin=freqmin, freqmax=freqmax)\n",
-    "\n",
-    "# # And trim:\n",
-    "# st.trim(starttime=starttime, endtime=endtime)\n"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -168,7 +135,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1296,9 +1263,7 @@
   {
    "cell_type": "code",
    "execution_count": 18,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -2342,9 +2307,7 @@
   {
    "cell_type": "code",
    "execution_count": 21,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -4360,9 +4323,7 @@
   {
    "cell_type": "code",
    "execution_count": 24,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -5375,9 +5336,7 @@
   {
    "cell_type": "code",
    "execution_count": 25,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -10349,7 +10308,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -10363,7 +10322,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.9.16"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Fixed deprecation bugs to allow for compatability with numpy >= 1.20 by replacing 'np.int' with 'np.int64'

Made compatible with pandas >= 2.0 by removing uses of pd.append. this behaviour is heavily discouraged by pandas devs as appending a dataframe does not happen "in place" lsit it does for lists and instead creates a new datafram which is significantly more expensive. This stackoverflow thread gives a nice exapliner https://stackoverflow.com/questions/75956209/dataframe-object-has-no-attribute-append

I have tried where possible to minimise the concateneting of arrays, whilst still preserving the current strcutre of the code