### PR TITLE
Date refactor

### DIFF
--- a/SeisSeeker/processing/detection.py
+++ b/SeisSeeker/processing/detection.py
@@ -573,7 +573,7 @@ class setup_detection:
                     print(f"Processing for hour: {hour:02d}")
                     if self.starttime >= obspy.UTCDateTime(year=date.year, month=date.month, day=date.day, hour=hour) + 3600:
                         continue
-                    if self.endtime < obspy.UTCDateTime(year=date.year, month=date.month, day=date.day, hour=hour):
+                    if self.endtime <= obspy.UTCDateTime(year=date.year, month=date.month, day=date.day, hour=hour):
                         continue
 
                     # Create datastore:
@@ -633,6 +633,10 @@ class setup_detection:
                         tmp_df = pd.DataFrame({'t': t_series_out, 'power': powers, 'slowness': slownesses, 'back_azi': back_azis})
                         store_df = pd.concat([store_df, tmp_df])
 
+                        # And clear memory:
+                        del Psum_all, t_series, powers, slownesses, back_azis
+                        gc.collect()
+
                     store_df.reset_index(drop=True, inplace=True)
 
                     # And save data out:
@@ -643,9 +647,7 @@ class setup_detection:
                     # And append fname to history:
                     self.out_fnames_array_proc.append(out_fname)
 
-                    # And clear memory:
-                    del Psum_all, t_series, powers, slownesses, back_azis
-                    gc.collect()
+
                         
         return None
 


### PR DESCRIPTION
Refactor how dates are handles in run_array_proc and throughout package.

Reliance on julian date format has been **removed** in favour of the more human readable YYYYMMDD-HH format. 

Internally the manual coding of days (i.e. days = range(0,367)) has been removed in favour of using datetime.date obejcts. This allows for a more consistent handling of dates for queries of different lengths

An additional bonus is that we can now iterate over the *exact* number of days between the search start/end parameters instead of having to loop over an additonal year and skip days outside of the search range. This also means I have been able to remove one layer of nested for loops, which should (marginally) improve performance. 

There are a few other small bug fixes, see relevent commit comments.

I will raise an issue to generalise data reading so SeisSeeker can be agnostic to what format is used [this will probably require the use of a flag somewhere]